### PR TITLE
Clean and fix initialization of DogStatsd

### DIFF
--- a/flask_datadog.py
+++ b/flask_datadog.py
@@ -22,20 +22,45 @@ class StatsD(object):
             self.app = None
 
     def init_app(self, app, config=None):
+        """
+        Initialize Datadog DogStatsd client from Flask app
+
+        Available config settings:
+
+          STATSD_HOST - statsd host to send metrics to (default: 'localhost')
+          STATSD_NAMESPACE - metric name prefix to use, e.g. 'app_name' (default: None)
+          STATSD_PORT - statsd port to send metrics to (default: 8125)
+          STATSD_TAGS - list of tags to include by default, e.g. ['env:prod'] (default: None)
+          STATSD_USEMS - whether or not to report timing in milliseconds (default: False)
+
+        :param app: Flask app to configure this client for
+        :type app: flask.Flask
+
+        :param config: optional, dictionary of config values (defaults to `app.config`)
+        :type config: dict
+        """
+        # Used passed in config if provided, otherwise use the config from `app`
         if config is not None:
             self.config = config
         elif self.config is None:
             self.config = app.config
 
+        # Set default values for expected config properties
         self.config.setdefault('STATSD_HOST', 'localhost')
+        self.config.setdefault('STATSD_NAMESPACE', None)
         self.config.setdefault('STATSD_PORT', 8125)
         self.config.setdefault('STATSD_TAGS', None)
         self.config.setdefault('STATSD_USEMS', False)
 
         self.app = app
 
-        self.statsd = DogStatsd(self.config['STATSD_HOST'],
-                                self.config['STATSD_PORT'], self.config['STATSD_TAGS'])
+        # Configure DogStatsd client
+        # https://github.com/DataDog/datadogpy/blob/v0.11.0/datadog/dogstatsd/base.py
+        self.statsd = DogStatsd(host=self.config['STATSD_HOST'],
+                                port=self.config['STATSD_PORT'],
+                                namespace=self.config['STATSD_NAMESPACE'],
+                                constant_tags=self.config['STATSD_TAGS'],
+                                use_ms=self.config['STATSD_USEMS'])
 
     @property
     def use_ms(self):


### PR DESCRIPTION
When I was testing `Flask-Datadog` I noticed that my `STATSD_TAGS` were not being applied to the metrics. After some sleuthing I found that we are initializing `DogStatsd` incorrectly, since keyword names were not being used, `STATSD_TAGS` was actually being passed in for `max_buffer_size`.

In this PR we are changing the initialization of `DogStatsd` to use keyword args. As well, we are adding some comments/documentation for `init_app`, and adding in the additional `STATSD_NAMESPACE` config setting (we are omitting `max_buffer_size` since we aren't exposing `__enter__` and `__exit__` yet, so the setting wouldn't be used anyways).
