### PR TITLE
Add API class to configure datadog api client

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,10 +19,11 @@ Usage
 You only need to import and initialize your app ::
 
     from flask import Flask
-    from flask.ext.datadog import StatsD
+    from flask.ext.datadog import API, StatsD
 
     app = Flask(__name__)
     app.config['STATSD_HOST'] = 'statsd.local'
+    app.config['DATADOG_API_KEY']  = 'api_key'
+    app.config['DATADOG_APP_KEY']  = 'app_key'
     statsd = StatsD(app)
-
-
+    dogapi = API(app)


### PR DESCRIPTION
Fixes #3 

In this PR we are adding a new class `flask.ext.datadog.API` which allows us to configure `datadog.api` from Flask app config.

This class works similar to the `StatsD` one where we are basically creating a proxy class for the `datadog.api` module.

One thing to note about this class is that we use `datadog.initialize` to configure the datadog api client. This is a global configuration, rather than a per-instance type configuration like `DogStatsd`.
