### PR TITLE
statsd: fix typo in `AttributeError` exception

### DIFF
--- a/flask_datadog.py
+++ b/flask_datadog.py
@@ -226,7 +226,7 @@ class StatsD(object):
         # If `self.statsd` has the attribute then return that attribute
         if self.statsd and hasattr(self.statsd, name):
             return getattr(self.statsd, name)
-        raise AttributeError('\'StatsD\' has has attribute \'{name}\''.format(name=name))
+        raise AttributeError('\'StatsD\' has no attribute \'{name}\''.format(name=name))
 
     def __enter__(self):
         """


### PR DESCRIPTION
### Description
It seems the error message should read 'has no attribute' but it reads 'has has attribute'.